### PR TITLE
Consolidate datapoints to improve rendering performance.

### DIFF
--- a/js/giraffe.js
+++ b/js/giraffe.js
@@ -222,11 +222,11 @@ generateGraphiteTargets = function(targets) {
   return graphite_targets;
 };
 
-generateDataURL = function(targets, annotator_target) {
+generateDataURL = function(targets, annotator_target, width) {
   var data_targets;
   annotator_target = annotator_target ? "&target=" + annotator_target : "";
   data_targets = generateGraphiteTargets(targets);
-  return "" + graphite_url + "/render?from=-" + period + "minutes&" + data_targets + annotator_target + "&format=json&jsonp=?";
+  return "" + graphite_url + "/render?from=-" + period + "minutes&" + data_targets + annotator_target + "&maxDataPoints=" + width + "&format=json&jsonp=?";
 };
 
 generateEventsURL = function(event_tags) {
@@ -262,7 +262,7 @@ createGraph = function(anchor, metric) {
     unstack: metric.unstack,
     stroke: metric.stroke === false ? false : true,
     strokeWidth: metric.stroke_width,
-    dataURL: generateDataURL(metric.target || metric.targets),
+    dataURL: generateDataURL(metric.target || metric.targets, $("" + anchor + " .chart").width()),
     onRefresh: function(transport) {
       return refreshSummary(transport);
     },
@@ -474,7 +474,7 @@ Rickshaw.Graph.JSONP.Graphite = Rickshaw.Class.create(Rickshaw.Graph.JSONP, {
     this.period = period;
     return deferred = $.ajax({
       dataType: 'json',
-      url: generateDataURL(this.args.targets, this.args.annotator_target),
+      url: generateDataURL(this.args.targets, this.args.annotator_target, this.args.width),
       error: this.error.bind(this)
     });
   }


### PR DESCRIPTION
Consolidate datapoints over the whole period when the datapoints would
exceed the pixel width of the graph, thus saving network bandwidth and
browser work.

To get this to work you would need a patched version of graphite, which I guess renders this pull request a little pointless. Anyhow I tried to do the consolidation on the client to save patching graphite but the performance was still poor over the extended time periods. 

https://github.com/philiphoy/graphite-web/commit/7adc7f453132142aa8afa1dbd6b4b11a65efa353
