### PR TITLE
Added support for passing max value configuration to rickshaw

### DIFF
--- a/js/giraffe.js
+++ b/js/giraffe.js
@@ -256,6 +256,7 @@ createGraph = function(anchor, metric) {
     width: $("" + anchor + " .chart").width(),
     height: metric.height || 300,
     min: metric.min || 0,
+    max: metric.max || 0,
     null_as: metric.null_as === void 0 ? null : metric.null_as,
     renderer: metric.renderer || 'area',
     interpolation: metric.interpolation || 'step-before',

--- a/js/src/giraffe.coffee
+++ b/js/src/giraffe.coffee
@@ -176,6 +176,7 @@ createGraph = (anchor, metric) ->
     width: $("#{anchor} .chart").width()
     height: metric.height || 300
     min: metric.min || 0
+    max: metric.max || 0
     null_as: if metric.null_as is undefined then null else metric.null_as
     renderer: metric.renderer || 'area'
     interpolation: metric.interpolation || 'step-before'


### PR DESCRIPTION
This pull request adds support to pass the max value configuration to rickshaw:

```
max
Highest value on the Y-axis. Defaults to the highest value in the series.
```
